### PR TITLE
Prevents translation of "Branding" across UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="google" content="notranslate" />
     <title>thotlabs</title>
     <meta name="description" content="Lovable Generated Project" />
     <meta name="author" content="Lovable" />

--- a/src/components/ContactSection.backup.tsx
+++ b/src/components/ContactSection.backup.tsx
@@ -240,7 +240,7 @@ const ContactSection = () => {
                     disabled={isSubmitting}
                   >
                     <option value="">Selecciona un servicio</option>
-                    <option value="Branding">Branding</option>
+                    <option value="Branding"><span translate="no" lang="en">Branding</span></option>
                     <option value="Redes Sociales">Redes Sociales</option>
                     <option value="Publicidad Digital">Publicidad Digital</option>
                     <option value="Diseño Web">Diseño Web</option>

--- a/src/components/ContactSection.tsx
+++ b/src/components/ContactSection.tsx
@@ -350,7 +350,7 @@ const ContactSection = () => {
                     disabled={isSubmitting}
                   >
                     <option value="">Selecciona un servicio</option>
-                    <option value="Branding">Branding</option>
+                    <option value="Branding"><span translate="no" lang="en">Branding</span></option>
                     <option value="Redes Sociales">Redes Sociales</option>
                     <option value="Publicidad Digital">Publicidad Digital</option>
                     <option value="Diseño Web">Diseño Web</option>

--- a/src/components/ContactSectionFixed.tsx
+++ b/src/components/ContactSectionFixed.tsx
@@ -276,7 +276,7 @@ const ContactSection = () => {
                     disabled={isSubmitting}
                   >
                     <option value="">Selecciona un servicio</option>
-                    <option value="Branding">Branding</option>
+                    <option value="Branding"><span translate="no" lang="en">Branding</span></option>
                     <option value="Redes Sociales">Redes Sociales</option>
                     <option value="Publicidad Digital">Publicidad Digital</option>
                     <option value="Diseño Web">Diseño Web</option>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,6 +2,14 @@ import React from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { Facebook, Instagram, Mail, Phone, MapPin } from 'lucide-react';
 
+// Helper function to render text with translation protection
+const renderTranslationSafeText = (text: string) => {
+  if (text === "Branding") {
+    return <span translate="no" lang="en">{text}</span>;
+  }
+  return text;
+};
+
 // X (Twitter) SVG icon as a React component
 const XIcon = ({ className = "" }) => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 509.64" className={className} fill="currentColor">
@@ -104,7 +112,7 @@ const Footer = () => {
                         className="text-nexo-blue-200 hover:text-white transition-colors flex items-center space-x-2"
                       >
                         {link.icon && <span>{link.icon}</span>}
-                        <span>{link.name}</span>
+                        <span>{renderTranslationSafeText(link.name)}</span>
                       </a>
                     ) : (
                       <button
@@ -112,7 +120,7 @@ const Footer = () => {
                         className="text-nexo-blue-200 hover:text-white transition-colors flex items-center space-x-2 text-left"
                       >
                         {link.icon && <span>{link.icon}</span>}
-                        <span>{link.name}</span>
+                        <span>{renderTranslationSafeText(link.name)}</span>
                       </button>
                     )}
                   </li>

--- a/src/components/ServicesSection.tsx
+++ b/src/components/ServicesSection.tsx
@@ -4,6 +4,14 @@ import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Brain, Globe, Palette, Share2, Megaphone, Settings } from 'lucide-react';
 
+// Helper function to render text with translation protection
+const renderTranslationSafeText = (text: string) => {
+  if (text === "Branding") {
+    return <span translate="no" lang="en">{text}</span>;
+  }
+  return text;
+};
+
 const ServicesSection = () => {
   const navigate = useNavigate();
   const services = [
@@ -80,7 +88,7 @@ const ServicesSection = () => {
                     {service.icon}
                   </div>
                   <h3 className="font-bold text-lg group-hover:text-nexo-orange-500 transition-colors">
-                    {service.title}
+                    {renderTranslationSafeText(service.title)}
                   </h3>
                 </div>
                 <p className="text-muted-foreground text-sm leading-relaxed text-enhanced-contrast">

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -8,6 +8,13 @@ import { Card } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Brain, Globe, Palette, Share2, Megaphone, Settings, CheckCircle, ArrowRight } from 'lucide-react';
 
+// Helper function to render text with translation protection
+const renderTranslationSafeText = (text: string) => {
+  if (text === "Branding") {
+    return <span translate="no" lang="en">{text}</span>;
+  }
+  return text;
+};
 const Services = () => {
   const [isDark, setIsDark] = useState(false);
   const location = useLocation();
@@ -173,7 +180,7 @@ const Services = () => {
                         </div>
                         <div>
                           <h2 className="text-xl font-bold text-foreground">
-                            {service.title}
+                            {renderTranslationSafeText(service.title)}
                           </h2>
                         </div>
                       </div>
@@ -212,7 +219,7 @@ const Services = () => {
                         </div>
                         <div>
                           <h2 className="text-xl font-bold text-foreground">
-                            {service.title}
+                            {renderTranslationSafeText(service.title)}
                           </h2>
                         </div>
                       </div>


### PR DESCRIPTION
This pull request introduces translation protection for the word "Branding" across the site to prevent it from being auto-translated by browsers or translation tools. The main changes involve wrapping "Branding" in a `<span>` with `translate="no"` and `lang="en"` attributes wherever it appears in UI components, including dropdowns, service listings, and navigation links. Helper functions are added to centralize this logic and ensure consistency.

**Translation protection for "Branding":**

* Added a helper function `renderTranslationSafeText` in `src/components/Footer.tsx`, `src/components/ServicesSection.tsx`, and `src/pages/Services.tsx` to render "Branding" with translation protection. [[1]](diffhunk://#diff-0dce242c6c493ad784b03374bef9541bc63a42693fdb79e88c6dda5e76fbac04R5-R12) [[2]](diffhunk://#diff-00462a69aed681bd150c78592731ef2c85cdc4465dd15fd16b427b3c5cdb33b7R7-R14) [[3]](diffhunk://#diff-4b42a0502a14ede548ba09e3e028a759e8914c9081c23f42a620e596fe58e357R11-R17)
* Updated service dropdowns in `src/components/ContactSection.tsx`, `src/components/ContactSectionFixed.tsx`, and `src/components/ContactSection.backup.tsx` to wrap "Branding" in a `<span translate="no" lang="en">`. [[1]](diffhunk://#diff-f65cde9cb32b187bf6a1a729f0a372a2248f20309c4baf61e062b90406bfae2dL353-R353) [[2]](diffhunk://#diff-72c8657f2fef0cdc9e4c16eb52c620f10f742422dab6be933404888832dc1051L279-R279) [[3]](diffhunk://#diff-57757aa62188600aa9caae2b41a0a52d1448bf0f90a70e50cae0927865898cd7L243-R243)
* Modified service titles in listings and cards to use the helper function, ensuring "Branding" is protected in `src/components/ServicesSection.tsx` and `src/pages/Services.tsx`. [[1]](diffhunk://#diff-00462a69aed681bd150c78592731ef2c85cdc4465dd15fd16b427b3c5cdb33b7L83-R91) [[2]](diffhunk://#diff-4b42a0502a14ede548ba09e3e028a759e8914c9081c23f42a620e596fe58e357L176-R183) [[3]](diffhunk://#diff-4b42a0502a14ede548ba09e3e028a759e8914c9081c23f42a620e596fe58e357L215-R222)
* Updated navigation and footer links to use the translation-safe rendering for "Branding" in `src/components/Footer.tsx`.

**Meta tag for site-wide translation control:**

* Added `<meta name="google" content="notranslate" />` to `index.html` to further discourage automatic translation of the page.